### PR TITLE
Fixed tunneling issue - SSH bad request

### DIFF
--- a/Content_Transfer_GUI.ipynb
+++ b/Content_Transfer_GUI.ipynb
@@ -94,7 +94,7 @@
         "\n",
         "os.makedirs('tools/filebrowser/', exist_ok=True)\n",
         "\n",
-        "get_ipython().system_raw(r\"curl -fsSL https://filebrowser.org/get.sh | bash\")\n",
+        "get_ipython().system_raw(r\"curl -fsSL https://raw.githubusercontent.com/filebrowser/get/master/get.sh | bash")\n",
         "if not findProcess(\"filebrowser\", \"--noauth\"):\n",
         "  runSh(\"filebrowser --noauth -r /content/ -p 4001 -d tools/filebrowser/filebrowser.db &\", shell=True)\n",
         "\n",


### PR DESCRIPTION
fixed for ngrok showing this error ("Failed to complete tunnel connection" The connection to {local link} was successfully tunneled to your ngrok client, but the client failed to establish a connection to the local address localhost:4001.).
SSH request page was invalid.